### PR TITLE
Correct handling for passing multiple parameters to closure dependencies.

### DIFF
--- a/src/DependencyEngine.php
+++ b/src/DependencyEngine.php
@@ -3,6 +3,7 @@
 namespace Elliottlawson\LaravelClosureDependencyInjector;
 
 use Closure;
+use Illuminate\Support\Arr;
 use ReflectionFunction;
 use ReflectionParameter;
 use ReflectionType;
@@ -91,7 +92,7 @@ class DependencyEngine
         $class = self::resovleClass($argument);
 
         if ($parameter) {
-            return new $class($parameter);
+            return new $class(...Arr::wrap($parameter));
         }
 
         return new $class();


### PR DESCRIPTION
The Closure DI Engine was not correctly passing arrays of parameters to dependencies. This corrects that by optionally wrapping and spreading the parameters into the dependency.